### PR TITLE
Released v1.5: A whole lot of goodness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+composer.lock
+coverage/
+.idea/
+vendor/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+  - '7.2'
+  - '7.3'
+
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source
+
+script: 
+  - mkdir -p build/logs
+  - php vendor/bin/phpstan analyze --level max src
+  - vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## Released v1.5: A whole lot of goodness.  2019-04-10 
+* [Major] Definitely require PHP 7.2, and BCMath for dev.
+* [Major] (#1) Completely reimplemented bcround() and fixed serious bugs.
+* [Major] Fixed the precision problems in BCMathCalcStrategy.
+* [Major] Fixed the precision problems in NativeCalcStrategy.
+* [Major] Added a whole bunch of type saftey to modding native numbers.
+* [Major] Added 100% Unit Test code coverage. Hurray!
+* [Major] Added the I_AM_A_DUMMY functionality to NativeCalc->modulus().
+* [minor] Fixed the copyright headers.
+* [minor] Added a mechanism to dynamically test whether extension paths work.
+* [minor] Added functionality to find out what strategy Money is using.
+* Reimplemented NativeCalcStrat's compare().
+* Added phpstan and fixed every type discrepancy.
+* Added TravisCI support.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 PHP Experts, Inc.
+Copyright (c) 2017-2019 PHP Experts, Inc. <www.phpexperts.pro>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   },
   "require-dev": {
     "ext-bcmath": "*",
-    "phpunit/phpunit": "7.*"
+    "phpunit/phpunit": "7.*",
+    "phpstan/phpstan-shim": "^0.11.5"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,21 +2,24 @@
   "name": "phpexpertsinc/money-type",
   "description": "A PHP library for a precise money handling data type. Avoids floating point rounding errors.",
   "license": "MIT",
-  "keywords": ["php", "money", "currency"],
+  "keywords": ["php", "money", "currency", "precise", "precision"],
   "authors": [
     {
       "name": "Theodore R. Smith",
       "email": "theodore@phpexperts.pro"
     }
   ],
-  "require": {},
+  "require": {
+    "php": "^7.2"
+  },
   "require-dev": {
-    "phpunit/phpunit": "^5.7"
+    "ext-bcmath": "*",
+    "phpunit/phpunit": "7.*"
   },
   "autoload": {
     "psr-4": {
       "PHPExperts\\MoneyType\\": "src",
-      "tests\\PHPExperts\\MoneyType\\": "tests"
+      "PHPExperts\\MoneyType\\Tests\\": "tests"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="main">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/BCMathCalcStrategy.php
+++ b/src/BCMathCalcStrategy.php
@@ -57,7 +57,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function multiply($rightOperand)
@@ -79,7 +79,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $modulus
+     * @param string $modulus
      * @return string
      */
     public function modulus($modulus)
@@ -101,7 +101,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
  * Based off of https://stackoverflow.com/a/1653826/430062
  * Thanks, [Alix Axel](https://stackoverflow.com/users/89771/alix-axel)!
  *
- * @param $number
+ * @param string $number
  * @param int $precision
  * @return string
  */
@@ -113,5 +113,5 @@ function bcround($number, $precision = BCMathCalcStrategy::PRECISION)
     }
 
     // Pad it out to the desired precision.
-    return number_format($number, $precision);
+    return number_format((double) $number, $precision);
 }

--- a/src/BCMathCalcStrategy.php
+++ b/src/BCMathCalcStrategy.php
@@ -96,3 +96,22 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
         return bccomp($rightOperand, $this->leftOperand, self::PRECISION);
     }
 }
+
+/**
+ * Based off of https://stackoverflow.com/a/1653826/430062
+ * Thanks, [Alix Axel](https://stackoverflow.com/users/89771/alix-axel)!
+ *
+ * @param $number
+ * @param int $precision
+ * @return string
+ */
+function bcround($number, $precision = BCMathCalcStrategy::PRECISION)
+{
+    if (strpos($number, '.') !== false) {
+        if ($number[0] != '-') return bcadd($number, '0.' . str_repeat('0', $precision) . '5', $precision);
+        return bcsub($number, '0.' . str_repeat('0', $precision) . '5', $precision);
+    }
+
+    // Pad it out to the desired precision.
+    return number_format($number, $precision);
+}

--- a/src/BCMathCalcStrategy.php
+++ b/src/BCMathCalcStrategy.php
@@ -17,6 +17,8 @@ namespace PHPExperts\MoneyType;
 
 final class BCMathCalcStrategy implements MoneyCalculationStrategy
 {
+    public const PRECISION = 10;
+
     private $leftOperand;
 
     public function __construct($leftOperand)
@@ -38,7 +40,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
      */
     public function add($rightOperand)
     {
-        $this->leftOperand = bcadd($this->leftOperand, $rightOperand, 10);
+        $this->leftOperand = bcadd($this->leftOperand, $rightOperand, self::PRECISION);
 
         return $this->leftOperand;
     }
@@ -49,7 +51,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
      */
     public function subtract($rightOperand)
     {
-        $this->leftOperand = bcsub($this->leftOperand, $rightOperand, 10);
+        $this->leftOperand = bcsub($this->leftOperand, $rightOperand, self::PRECISION);
 
         return $this->leftOperand;
     }
@@ -60,7 +62,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
      */
     public function multiply($rightOperand)
     {
-        $this->leftOperand = bcmul($this->leftOperand, $rightOperand, 10);
+        $this->leftOperand = bcmul($this->leftOperand, $rightOperand, self::PRECISION);
 
         return $this->leftOperand;
     }
@@ -71,7 +73,7 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
      */
     public function divide($rightOperand)
     {
-        $this->leftOperand = bcdiv($this->leftOperand, $rightOperand, 10);
+        $this->leftOperand = bcdiv($this->leftOperand, $rightOperand, self::PRECISION);
 
         return $this->leftOperand;
     }
@@ -82,15 +84,15 @@ final class BCMathCalcStrategy implements MoneyCalculationStrategy
      */
     public function modulus($modulus)
     {
-        return bcmod($this->leftOperand, $modulus);
+        return bcmod($this->leftOperand, $modulus, self::PRECISION);
     }
 
     /**
      * @param string $rightOperand
-     * @return int
+     * @return int 0 if equal, -1 if $rightOperand is less, 1 if it is greater.
      */
     public function compare($rightOperand)
     {
-        return bccomp($this->leftOperand, $rightOperand);
+        return bccomp($rightOperand, $this->leftOperand, self::PRECISION);
     }
 }

--- a/src/BCMathCalcStrategy.php
+++ b/src/BCMathCalcStrategy.php
@@ -1,11 +1,17 @@
 <?php
-// This file is a part of the MoneyType library, a PHPExperts.pro Project.
-//
-// Copyright (c) 2017 PHP Experts, Inc. <www.phpexperts.pro>
-// Authored by Theodore R. Smith <theodore@phpexperts.pro>
-// * 2017-05-01 14:38 IST
-//
-// This file is licensed under the terms of the MIT license:
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2017-2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  @ 2017-05-01 14:38 IST
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
 
 namespace PHPExperts\MoneyType;
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -15,6 +15,8 @@
 
 namespace PHPExperts\MoneyType;
 
+use ReflectionClass;
+
 class Money implements MoneyCalculationStrategy
 {
     protected $strategy;
@@ -54,6 +56,11 @@ class Money implements MoneyCalculationStrategy
     public function __toString()
     {
         return $this->strategy->__toString();
+    }
+
+    public function getStrategy(): string
+    {
+        return (new ReflectionClass($this->strategy))->getShortName();
     }
 
     /**

--- a/src/Money.php
+++ b/src/Money.php
@@ -28,7 +28,7 @@ class Money implements MoneyCalculationStrategy
      */
     /**
      * Money constructor.
-     * @param $amount
+     * @param string $amount
      * @param MoneyCalculationStrategy|null $calcStrategy
      * @param callable|null $hasBCMath
      */
@@ -64,7 +64,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function add($rightOperand)
@@ -73,7 +73,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function subtract($rightOperand)
@@ -82,7 +82,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function multiply($rightOperand)
@@ -91,7 +91,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function divide($rightOperand)
@@ -100,7 +100,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $modulus
+     * @param string $modulus
      * @return int
      */
     public function modulus($modulus)
@@ -109,7 +109,7 @@ class Money implements MoneyCalculationStrategy
     }
 
     /**
-     * @param float $rightOperand
+     * @param string $rightOperand
      * @return int
      */
     public function compare($rightOperand)

--- a/src/Money.php
+++ b/src/Money.php
@@ -24,10 +24,22 @@ class Money implements MoneyCalculationStrategy
      * @param string $amount
      * @param MoneyCalculationStrategy|null $calcStrategy
      */
-    public function __construct($amount, MoneyCalculationStrategy $calcStrategy = null)
+    /**
+     * Money constructor.
+     * @param $amount
+     * @param MoneyCalculationStrategy|null $calcStrategy
+     * @param callable|null $hasBCMath
+     */
+    public function __construct($amount, MoneyCalculationStrategy $calcStrategy = null, callable $hasBCMath = null)
     {
+        if (!$hasBCMath) {
+            $hasBCMath = function(): bool {
+                return extension_loaded('bcmath');
+            };
+        }
+
         if (!$calcStrategy) {
-            if (extension_loaded('bcmath')) {
+            if ($hasBCMath()) {
                 $calcStrategy = new BCMathCalcStrategy($amount);
             } else {
                 $calcStrategy = new NativeCalcStrategy($amount);

--- a/src/Money.php
+++ b/src/Money.php
@@ -117,17 +117,3 @@ class Money implements MoneyCalculationStrategy
         return $this->strategy->compare($rightOperand);
     }
 }
-
-/**
- * @param $number
- * @param int $precision
- * @return string
- */
-function bcround($number, $precision = 0)
-{
-    if (strpos($number, '.') !== false) {
-        if ($number[0] != '-') return bcadd($number, '0.' . str_repeat('0', $precision) . '5', $precision);
-        return bcsub($number, '0.' . str_repeat('0', $precision) . '5', $precision);
-    }
-    return $number;
-}

--- a/src/Money.php
+++ b/src/Money.php
@@ -1,11 +1,17 @@
 <?php
-// This file is a part of the MoneyType library, a PHPExperts.pro Project.
-//
-// Copyright (c) 2017 PHP Experts, Inc. <www.phpexperts.pro>
-// Authored by Theodore R. Smith <theodore@phpexperts.pro>
-//  * 2017-05-01 14:17 IST
-//
-// This file is licensed under the terms of the MIT license:
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2017-2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  @ 2017-05-01 14:17 IST
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
 
 namespace PHPExperts\MoneyType;
 

--- a/src/MoneyCalculationStrategy.php
+++ b/src/MoneyCalculationStrategy.php
@@ -1,11 +1,17 @@
 <?php
-// This file is a part of the MoneyType library, a PHPExperts.pro Project.
-//
-// Copyright (c) 2017 PHP Experts, Inc. <www.phpexperts.pro>
-// Authored by Theodore R. Smith <theodore@phpexperts.pro>
-// * 2017-05-01 14:31 IST
-//
-// This file is licensed under the terms of the MIT license:
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2017-2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  @ 2017-05-01 14:31 IST
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
 
 namespace PHPExperts\MoneyType;
 

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -15,6 +15,8 @@
 
 namespace PHPExperts\MoneyType;
 
+use InvalidArgumentException;
+
 final class NativeCalcStrategy implements MoneyCalculationStrategy
 {
     private $leftOperand;
@@ -98,7 +100,31 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
      */
     public function modulus($modulus)
     {
-        return ($this->leftOperand / 100) % $modulus;
+        /**
+         * Determines if a variable appears to be a float or not.
+         *
+         * @param string|int|double $number
+         * @return bool True if it appears to be an integer value. "75.0000" returns false.
+         * @throws InvalidArgumentException if $number is not a valid number.
+         */
+        $isFloatLike = function($number): bool {
+            // Bail if it isn't even a number.
+            if (!is_numeric($number)) {
+                throw new InvalidArgumentException("'$number' is not a valid number.");
+            }
+
+            // Try to convert the variable to a float.
+            $floatVal = floatval($number);
+
+            // If the parsing succeeded and the value is not equivalent to an int, it's probably a float.
+            return ($floatVal && intval($floatVal) != $floatVal);
+        };
+
+        if ($isFloatLike($modulus)) {
+            throw new InvalidArgumentException('Cannot compute non-integer moduli.');
+        }
+
+        return (string) (($this->leftOperand / 100) % $modulus);
     }
 
     /**

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -27,12 +27,12 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     /**
      * Converts a float/double to an int with no precision loss.
      *
-     * @param float $float
+     * @param string $float
      * @return int
      */
     private function convertToCents($float)
     {
-        return (int)round($float * 100);
+        return (int)round((double) $float * 100);
     }
 
     public function __construct($leftOperand)
@@ -50,7 +50,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
 
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function add($rightOperand)
@@ -62,7 +62,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function subtract($rightOperand)
@@ -73,7 +73,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function multiply($rightOperand)
@@ -85,7 +85,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $rightOperand
+     * @param string $rightOperand
      * @return string
      */
     public function divide($rightOperand)
@@ -138,7 +138,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param float $rightOperand
+     * @param string $rightOperand
      * @return int 0 if equal, -1 if $rightOperand is less, 1 if it is greater.
      */
     public function compare($rightOperand)

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -139,18 +139,12 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
 
     /**
      * @param float $rightOperand
-     * @return int
+     * @return int 0 if equal, -1 if $rightOperand is less, 1 if it is greater.
      */
     public function compare($rightOperand)
     {
         $rightOperand = $this->convertToCents($rightOperand);
 
-        if ($this->leftOperand > $rightOperand) {
-            return 1;
-        } elseif ($this->leftOperand < $rightOperand) {
-            return -1;
-        } else {
-            return 0;
-        }
+        return $rightOperand <=> $this->leftOperand;
     }
 }

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -15,10 +15,13 @@
 
 namespace PHPExperts\MoneyType;
 
+use BadMethodCallException;
 use InvalidArgumentException;
 
 final class NativeCalcStrategy implements MoneyCalculationStrategy
 {
+    public const I_AM_A_DUMMY = 'But I really need this';
+
     private $leftOperand;
 
     /**
@@ -66,7 +69,6 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     {
         $rightOperand = $this->convertToCents($rightOperand);
         $this->leftOperand -= $rightOperand;
-
         return (string)round($this->leftOperand / 100, 2);
     }
 
@@ -95,10 +97,11 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     }
 
     /**
-     * @param $modulus
-     * @return int
+     * @param string|int|float $modulus It must be a float-like
+     * @param string $iAmStupid Do you really want an imprecise modulus with a precision package??
+     * @return string
      */
-    public function modulus($modulus)
+    public function modulus($modulus, string $iAmStupid = '')
     {
         /**
          * Determines if a variable appears to be a float or not.
@@ -121,7 +124,14 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
         };
 
         if ($isFloatLike($modulus)) {
-            throw new InvalidArgumentException('Cannot compute non-integer moduli.');
+            throw new InvalidArgumentException('Cannot compute non-integer moduli: Install ext-bcmath.');
+        }
+
+        if ($iAmStupid !== self::I_AM_A_DUMMY) {
+            throw new BadMethodCallException(
+                'You CANNOT get precise a modulus answer via Native PHP. ' . "\n" .
+                'Install ext-bcmath (preferred) or set $iAmStupid to true.'
+            );
         }
 
         return (string) (($this->leftOperand / 100) % $modulus);

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -1,11 +1,17 @@
 <?php
-// This file is a part of the MoneyType library, a PHPExperts.pro Project.
-//
-// Copyright (c) 2017 PHP Experts, Inc. <www.phpexperts.pro>
-// Authored by Theodore R. Smith <theodore@phpexperts.pro>
-// * 2017-05-01 14:38 IST
-//
-// This file is licensed under the terms of the MIT license:
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2017-2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  @ 2017-05-01 14:38 IST
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
 
 namespace PHPExperts\MoneyType;
 

--- a/src/NativeCalcStrategy.php
+++ b/src/NativeCalcStrategy.php
@@ -40,7 +40,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
      */
     public function __toString()
     {
-        return (string)($this->leftOperand / 100);
+        return (string)round($this->leftOperand / 100, 2);
     }
 
 
@@ -53,7 +53,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
         $rightOperand = $this->convertToCents($rightOperand);
         $this->leftOperand += $rightOperand;
 
-        return (string)($this->leftOperand / 100);
+        return (string)round($this->leftOperand / 100, 2);
     }
 
     /**
@@ -65,7 +65,7 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
         $rightOperand = $this->convertToCents($rightOperand);
         $this->leftOperand -= $rightOperand;
 
-        return (string)($this->leftOperand / 100);
+        return (string)round($this->leftOperand / 100, 2);
     }
 
     /**
@@ -75,9 +75,9 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     public function multiply($rightOperand)
     {
         $rightOperand = $this->convertToCents($rightOperand);
-        $this->leftOperand *= $rightOperand;
+        $this->leftOperand *= $rightOperand / 100;
 
-        return (string)($this->leftOperand / 100);
+        return (string)round($this->leftOperand / 100, 2);
     }
 
     /**
@@ -87,9 +87,9 @@ final class NativeCalcStrategy implements MoneyCalculationStrategy
     public function divide($rightOperand)
     {
         $rightOperand = $this->convertToCents($rightOperand);
-        $this->leftOperand /= $rightOperand;
+        $this->leftOperand /= $rightOperand / 100;
 
-        return (string)($this->leftOperand / 100);
+        return (string)round($this->leftOperand / 100, 2);
     }
 
     /**

--- a/tests/BCMathCalcStrategyTest.php
+++ b/tests/BCMathCalcStrategyTest.php
@@ -71,4 +71,17 @@ class BCMathCalcStrategyTest extends TestCase
     {
         self::assertSame('0.0699993000', $this->calcStrat->modulus('0.1500001'));
     }
+
+    public function testCanRoundWithHighPrecision()
+    {
+        // Test high precision.
+        $expected = '-54.03';
+        $actual = bcround('-54.0300000000', 2);
+        self::assertSame($expected, $actual);
+
+        // Test no precision.
+        $expected = '-54.00';
+        $actual = bcround('-54', 2);
+        self::assertSame($expected, $actual);
+    }
 }

--- a/tests/BCMathCalcStrategyTest.php
+++ b/tests/BCMathCalcStrategyTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
+
+namespace PHPExperts\MoneyType\Tests;
+
+use PHPExperts\MoneyType\BCMathCalcStrategy;
+use function PHPExperts\MoneyType\bcround;
+use PHPUnit\Framework\TestCase;
+
+class BCMathCalcStrategyTest extends TestCase
+{
+    use MathCalcStrategyTestBase;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->calcStratName = BCMathCalcStrategy::class;
+        $this->calcStrat = new BCMathCalcStrategy('1.12');
+    }
+
+    public function testCanAddWithHighPrecision()
+    {
+        self::assertSame('56.1411133130', $this->calcStrat->add('55.021113313'));
+    }
+
+    public function testCanSubtractWithHighPrecision()
+    {
+        self::assertSame('-53.9011133130', $this->calcStrat->subtract('55.021113313'));
+    }
+
+    public function testCanMultiplyWithHighPrecision()
+    {
+        self::assertSame('61.6236469105', $this->calcStrat->multiply('55.021113313'));
+    }
+
+    public function testCanDivideWithHighPrecision()
+    {
+        self::assertSame('53.0470987665', $this->calcStrat->divide('0.021113313'));
+    }
+
+    public function testCanCompareTwoNumbersWithHighPrecision()
+    {
+        // Assert same with extra precision.
+        self::assertSame(0, $this->calcStrat->compare('1.120000000'));
+
+        // Assert is less with extra precision.
+        self::assertSame(-1, $this->calcStrat->compare('1.119999999'));
+
+        // Assert is more with extra precision.
+        self::assertSame(1, $this->calcStrat->compare('1.120000001'));
+    }
+
+    public function testCanComputeHighPrecisionModulus()
+    {
+        self::assertSame('1.1200000000', $this->calcStrat->modulus('2'));
+    }
+
+    public function testCanComputeTheModulusOfDecimals()
+    {
+        self::assertSame('0.0699993000', $this->calcStrat->modulus('0.1500001'));
+    }
+}

--- a/tests/MathCalcStrategyTestBase.php
+++ b/tests/MathCalcStrategyTestBase.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
+
+namespace PHPExperts\MoneyType\Tests;
+
+use PHPExperts\MoneyType\MoneyCalculationStrategy;
+
+trait MathCalcStrategyTestBase
+{
+    /** @var MoneyCalculationStrategy */
+    protected $calcStrat;
+
+    /** @var string */
+    protected $calcStratName;
+
+    // Inherited from PHPUnit.
+    abstract public static function assertInstanceOf(string $expected, $actual, string $message = ''): void;
+    abstract public static function assertIsString($actual, string $message = ''): void;
+    abstract public static function assertEquals($expected, $actual, string $message = '', float $delta = 0.0, int $maxDepth = 10, bool $canonicalize = false, bool $ignoreCase = false): void;
+    abstract public static function assertSame($expected, $actual, string $message = ''): void;
+
+    public function testCanBeInstantiatedWithAnInteger()
+    {
+        $bcMathStrat = new $this->calcStratName(1);
+        self::assertInstanceOf($this->calcStratName, $bcMathStrat);
+    }
+
+    public function testCanBeInstantiatedWithAFloat()
+    {
+        $bcMathStrat = new $this->calcStratName(1.0);
+        self::assertInstanceOf($this->calcStratName, $bcMathStrat);
+    }
+
+    public function testCanBeInstantiatedWithAString()
+    {
+        $bcMathStrat = new $this->calcStratName('1.11');
+        self::assertInstanceOf($this->calcStratName, $bcMathStrat);
+    }
+
+    public function testAccessTheObjectAsAStringToGetItsValuation()
+    {
+        $actual = '+' . $this->calcStrat . '+';
+        self::assertIsString($actual);
+
+        $expected = '+1.12+';
+        self::assertEquals($expected, $actual);
+        self::assertSame($expected, $actual);
+    }
+
+    public function testCanAddWithCentPrecision()
+    {
+        $output = $this->calcStrat->add('55.15');
+        self::assertSame('56.27', $this->calcStrat.'', "The literal output: $output");
+    }
+
+    public function testCanSubtractWithCentPrecision()
+    {
+        $output = $this->calcStrat->subtract('55.15');
+
+        self::assertSame('-54.03', $this->calcStrat.'', "The literal output: $output");
+    }
+
+    public function testCanMultiplyWithCentPrecision()
+    {
+        // Actual answer: 61.768
+        $output = $this->calcStrat->multiply('55.15');
+        self::assertSame('61.77', $this->calcStrat.'', "The literal output: $output");
+    }
+
+    public function testCanDivideWithCentPrecision()
+    {
+        $output = $this->calcStrat->divide('0.06');
+        self::assertEquals('18.67', $this->calcStrat.'', "The literal output: $output");
+    }
+
+    public function testCanCompareTwoNumbersWithCentPrecision()
+    {
+        // Assert same.
+        self::assertSame(0, $this->calcStrat->compare('1.12'));
+
+        // Assert is less.
+        self::assertSame(-1, $this->calcStrat->compare('1.11'));
+
+        // Assert is more.
+        self::assertSame(1, $this->calcStrat->compare('1.13'));
+    }
+}

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
+
+namespace PHPExperts\MoneyType\Tests;
+
+use PHPExperts\MoneyType\Money;
+use PHPExperts\MoneyType\MoneyCalculationStrategy;
+use PHPUnit\Framework\TestCase;
+
+class MoneyTest extends TestCase
+{
+    private static function assertCalcStrategy(Money $moneyType, string $expected)
+    {
+        $actual = $moneyType->getStrategy();
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function buildMockCalcStrategy(): MoneyCalculationStrategy
+    {
+        return new class implements MoneyCalculationStrategy
+        {
+            public function __toString()
+            {
+                return '0';
+            }
+
+            public function add($rightOperand)
+            {
+                return '1';
+            }
+
+            public function subtract($rightOperand)
+            {
+                return '2';
+            }
+
+            public function multiply($rightOperand)
+            {
+                return '3';
+            }
+
+            public function divide($rightOperand)
+            {
+                return '4';
+            }
+
+            public function modulus($modulus)
+            {
+                return '5';
+            }
+
+            public function compare($rightOperand)
+            {
+                return '6';
+            }
+        };
+    }
+
+    public function testWillReportWhatStrategyIsBeingUsed()
+    {
+        $moneyType = new Money(5);
+        self::assertCalcStrategy($moneyType, 'BCMathCalcStrategy');
+    }
+
+    public function testWillUseBCMathIfItIsAvailable()
+    {
+        $hasBCMath = function() {
+            return true;
+        };
+
+        $moneyType = new Money(5, null, $hasBCMath);
+        self::assertCalcStrategy($moneyType, 'BCMathCalcStrategy');
+    }
+
+    public function testWillFallBackToNativePhpIfNecessary()
+    {
+        $hasBCMath = function() {
+            return false;
+        };
+
+        $moneyType = new Money(5, null, $hasBCMath);
+        self::assertCalcStrategy($moneyType, 'NativeCalcStrategy');
+    }
+
+    public function testProxiesEverythingToItsCalculationStrategy()
+    {
+        $mockCalcStrat = self::buildMockCalcStrategy();
+        $moneyType = new Money(5, $mockCalcStrat);
+
+        $calcStratOps = get_class_methods($mockCalcStrat);
+        foreach ($calcStratOps as $index => $op) {
+            self::assertSame((string) $index, $moneyType->$op(0));
+        }
+    }
+}
+

--- a/tests/NativeCalcStrategyTest.php
+++ b/tests/NativeCalcStrategyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of MoneyType, a PHP Experts, Inc., Project.
+ *
+ * Copyright © 2019 PHP Experts, Inc.
+ * Author: Theodore R. Smith <theodore@phpexperts.pro>
+ *  GPG Fingerprint: 4BF8 2613 1C34 87AC D28F  2AD8 EB24 A91D D612 5690
+ *  https://www.phpexperts.pro/
+ *  https://github.com/phpexpertsinc/MoneyType
+ *
+ * This file is licensed under the MIT License.
+ */
+
+namespace PHPExperts\MoneyType\Tests;
+
+use InvalidArgumentException;
+use PHPExperts\MoneyType\NativeCalcStrategy;
+use PHPUnit\Framework\TestCase;
+
+class NativeCalcStrategyTest extends TestCase
+{
+    use MathCalcStrategyTestBase;
+
+    /** @var NativeCalcStrategy */
+    protected $calcStrat;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->calcStratName = NativeCalcStrategy::class;
+        $this->calcStrat = new NativeCalcStrategy('1.12');
+    }
+}

--- a/tests/NativeCalcStrategyTest.php
+++ b/tests/NativeCalcStrategyTest.php
@@ -32,4 +32,38 @@ class NativeCalcStrategyTest extends TestCase
         $this->calcStratName = NativeCalcStrategy::class;
         $this->calcStrat = new NativeCalcStrategy('1.12');
     }
+
+    public function testWontAttemptOperationsWithNonNumbers()
+    {
+        // @FIXME: This functionality needs to be expanded to EVERY operation -and- strategy.
+        try {
+            $this->calcStrat->modulus('Not A Number');
+            $this->fail('It somehow tried to compute a non-number modulus.');
+        }
+        catch (InvalidArgumentException $e) {
+            $this->assertEquals("'Not A Number' is not a valid number.", $e->getMessage());
+        }
+    }
+
+    public function testCannotComputeTheModulusOfDecimals()
+    {
+        try {
+            $this->calcStrat->modulus('0.1500001');
+            $this->fail('It somehow tried to compute a decimal modulus.');
+        }
+        catch (InvalidArgumentException $e) {
+            self::assertEquals('Cannot compute non-integer moduli: Install ext-bcmath.', $e->getMessage());
+        }
+    }
+
+    public function testWillThrowAnExceptionIfAskedToComputeAnIntegerModulus()
+    {
+        $this->expectException('BadMethodCallException');
+        $this->calcStrat->modulus('2');
+    }
+
+    public function testCanComputeTheModulusOfIntegersIfDevPassesIAmADummyParameter()
+    {
+        self::assertSame('1', $this->calcStrat->modulus('2', NativeCalcStrategy::I_AM_A_DUMMY));
+    }
 }


### PR DESCRIPTION
## Released v1.5: A whole lot of goodness.  2019-04-10 
* [Major] Definitely require PHP 7.1, and BCMath for dev.
* [Major] (#1) Completely reimplemented bcround() and fixed serious bugs.
* [Major] Fixed the precision problems in BCMathCalcStrategy.
* [Major] Fixed the precision problems in NativeCalcStrategy.
* [Major] Added a whole bunch of type saftey to modding native numbers.
* [Major] Added 100% Unit Test code coverage. Hurray!
* [Major] Added the I_AM_A_DUMMY functionality to NativeCalc->modulus().
* [minor] Fixed the copyright headers.
* [minor] Added a mechanism to dynamically test whether extension paths work.
* [minor] Added functionality to find out what strategy Money is using.
* Reimplemented NativeCalcStrat's compare().
* Added phpstan and fixed every type discrepancy.
* Added TravisCI support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/moneytype/2)
<!-- Reviewable:end -->
